### PR TITLE
Traverse condTreeComponents AST as well.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -17,5 +17,9 @@ stripVersionRestrictions pkg = pkg { condLibrary = fmap f2 (condLibrary pkg)
                                    }
   where
     f1 (string,condTree) = (string, f2 condTree)
-    f2 ct = ct { condTreeConstraints = map f3 (condTreeConstraints ct) }
+    f2 ct = ct { condTreeConstraints = map f3 (condTreeConstraints ct)
+               , condTreeComponents = map traverseAST (condTreeComponents ct)
+               }
     f3 (Dependency d _) = Dependency d anyVersion
+
+    traverseAST (c, ct1, ct2) = (c, f2 ct1, fmap f2 ct2)


### PR DESCRIPTION
We need to get rid of dependences within conditions as well, so we need to traverse the whole condTreeComponents AST.

This was discovered by @bluescreen303 within a comment in NixOS/nixpkgs@ba83178aed6a5af45ae4e453e62494312829183c.
