### PR TITLE
Relax `build-tool-depends`

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -48,6 +48,7 @@ relaxTest t = t { testBuildInfo = relaxBuildInfo (testBuildInfo t) }
 
 relaxBuildInfo :: BuildInfo -> BuildInfo
 relaxBuildInfo bi = bi { buildTools = map relax (buildTools bi)
+                       , buildToolDepends = map relax (buildToolDepends bi)
                        , targetBuildDepends = map relax (targetBuildDepends bi)
                        }
 
@@ -56,6 +57,9 @@ class DependencyType a where
 
 instance DependencyType Dependency where
   relax (Dependency d _ deps) = Dependency d anyVersion deps
+
+instance DependencyType ExeDependency where
+  relax (ExeDependency d u _) = ExeDependency d u anyVersion
 
 instance DependencyType LegacyExeDependency where
   relax (LegacyExeDependency d _) = LegacyExeDependency d anyVersion


### PR DESCRIPTION
I needed this today to jailbreak `purescript` properly: [NixOS/nixpkgs@`416f057` (#216144)](https://github.com/NixOS/nixpkgs/pull/216144/commits/416f057351a7cdaf36fd82e3df4af08633582399)

BTW I couldn't figure out how to build jailbreak-cabal with cabal, had to use the nixpkgs derivation.