### PR TITLE
Prevent constraint solver from picking incompatible Cabal-syntax

### DIFF
--- a/jailbreak-cabal.cabal
+++ b/jailbreak-cabal.cabal
@@ -13,12 +13,24 @@ license-file:           LICENSE
 build-type:             Simple
 cabal-version:          >= 1.10
 
+flag Cabal-syntax
+  description: Use the new Cabal-syntax package
+  default: True
+  manual: False
+
 source-repository head
   type: git
   location: https://github.com/NixOS/jailbreak-cabal
 
 executable jailbreak-cabal
   main-is: Main.hs
-  -- for Cabal < 3.7, the Cabal-syntax dummy package will be used
-  build-depends: base < 5, Cabal == 3.*, Cabal-syntax
+  build-depends: base < 5
+
+  -- This stunt is necessary to prevent the constraint solver from picking
+  -- Cabal-syntax >= 3.7 and Cabal < 3.7 at the same time.
+  if flag(Cabal-syntax)
+    build-depends: Cabal >= 3.7, Cabal-syntax >= 3.7
+  else
+    build-depends: Cabal >= 3 && < 3.7, Cabal-syntax < 3.7
+
   default-language: Haskell2010


### PR DESCRIPTION
Uses recommended setup from Cabal-syntax-3.6.0.0 README, but since we always need normal Cabal, it looks even sillier.

cc @ncfavier 