### PR TITLE
Bump version to 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Revision history for jailbreak-cabal
+
+## 1.4
+
+* jailbreak-cabal will now also relax version constraints on `build-tool-depends`.
+  See [#20](https://github.com/NixOS/jailbreak-cabal/pull/20).
+
+* Introduced new (automatic) cabal flag `Cabal-syntax` which should prevent
+  Cabal's constraint solver from picking incompatible versions of `Cabal` and
+  `Cabal-syntax` when using `cabal-install` to build jailbreak-cabal.
+  See [#22](https://github.com/NixOS/jailbreak-cabal/pull/22).

--- a/jailbreak-cabal.cabal
+++ b/jailbreak-cabal.cabal
@@ -1,5 +1,5 @@
 name:                   jailbreak-cabal
-version:                1.3.6
+version:                1.4
 synopsis:               Strip version restrictions from Cabal files
 description:            Strip version restrictions from build dependencies in Cabal files.
 category:               Distribution
@@ -12,6 +12,7 @@ license:                BSD3
 license-file:           LICENSE
 build-type:             Simple
 cabal-version:          >= 1.10
+extra-source-files:     CHANGELOG.md
 
 flag Cabal-syntax
   description: Use the new Cabal-syntax package


### PR DESCRIPTION
PVP does not prescribe this, but the update does change behavior, so it seems sensible to have a breaking release according to PVP.