### PR TITLE
Main.hs: support Cabal 3.14.0.0

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -10,12 +10,19 @@ import Distribution.PackageDescription.Parsec
 import Distribution.PackageDescription.PrettyPrint
 import Distribution.Types.ExeDependency
 import Distribution.Types.LegacyExeDependency
+#if MIN_VERSION_Cabal(3,14,0)
+import Distribution.Utils.Path
+#endif
 import Distribution.Verbosity
 import Distribution.Version
 import System.Environment
 
 main :: IO ()
+#if MIN_VERSION_Cabal(3,14,0)
+main = getArgs >>= mapM_ (\cabalFile -> readGenericPackageDescription silent Nothing (unsafeMakeSymbolicPath cabalFile) >>= writeGenericPackageDescription cabalFile . stripVersionRestrictions)
+#else
 main = getArgs >>= mapM_ (\cabalFile -> readGenericPackageDescription silent cabalFile >>= writeGenericPackageDescription cabalFile . stripVersionRestrictions)
+#endif
 
 -- We don't relax version restrictions inside conditional statements.
 -- See https://github.com/peti/jailbreak-cabal/commit/99eac40deb481b185fd93fd307625369ff5e1ec0


### PR DESCRIPTION
The type signature of [`readGenericPackageDescription`](https://hackage.haskell.org/package/Cabal-3.14.0.0/docs/Distribution-Simple-PackageDescription.html#v:readGenericPackageDescription) has changed, causing https://github.com/NixOS/nixpkgs/issues/369161. This appears to fix the build failure.